### PR TITLE
Add time import to make build work

### DIFF
--- a/zsond.go
+++ b/zsond.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 func parsePath(path string) (string, error) {


### PR DESCRIPTION
I tried to build `zsond` after the prior commit but it failed:

```
# go build
# _/Users/phil/work/zsond
./zsond.go:91:13: undefined: time
```

I'm not much of a Go programmer, but it fix looks simple enough, so here ya go. :)